### PR TITLE
fix: scrape resiliente a páginas mortas (404)

### DIFF
--- a/src/letras/pipeline.py
+++ b/src/letras/pipeline.py
@@ -7,6 +7,8 @@ Full-vs-incremental is a selection predicate, not a separate runner.
 
 from concurrent.futures import ThreadPoolExecutor
 
+import httpx
+
 from letras.domain.entities import Artist, Song
 from letras.domain.language import detect_language
 from letras.source.fetcher import Fetcher
@@ -43,7 +45,11 @@ def run(
 
     # Phase 1 (concurrent): fetch + parse each artist page into a flat work list.
     def list_songs(artist: Artist) -> tuple[Artist, list[Song]]:
-        songs = parse_artist_songs(fetcher.artist_page(artist.slug))
+        try:
+            html = fetcher.artist_page(artist.slug)
+        except httpx.HTTPError:
+            return artist, []  # dead/unreachable artist page -> skip it
+        songs = parse_artist_songs(html)
         if incremental:
             songs = [s for s in songs if s.slug not in known[artist.slug]]
         if max_songs is not None:
@@ -60,8 +66,8 @@ def run(
         artist, song = item
         try:
             content = parse_song(fetcher.song_page(artist.slug, song.slug))
-        except ParseError:
-            return None  # one malformed page never aborts the run
+        except (httpx.HTTPError, ParseError):
+            return None  # a dead or malformed page never aborts the run
         return artist, song, content, detect_language(content)
 
     with ThreadPoolExecutor(max_workers=workers) as pool:

--- a/src/letras/source/fetcher.py
+++ b/src/letras/source/fetcher.py
@@ -24,7 +24,7 @@ import time
 import httpx
 from tenacity import (
     Retrying,
-    retry_if_exception_type,
+    retry_if_exception,
     stop_after_attempt,
     wait_exponential,
 )
@@ -42,6 +42,16 @@ _INDEX_PATH = "/estilos/gospelreligioso/todosartistas.html"
 # We honor these explicitly (Retry-After + AIMD backoff) instead of treating
 # them as generic transient errors.
 _THROTTLE_CODES = frozenset({429, 503})
+# Transient statuses worth retrying. Permanent 4xx (404, 403, 410, …) fail fast.
+_RETRY_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+def _should_retry(exc: BaseException) -> bool:
+    if isinstance(exc, httpx.TransportError):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        return exc.response.status_code in _RETRY_CODES
+    return False
 
 
 def _parse_retry_after(value: str | None) -> float | None:
@@ -91,9 +101,7 @@ class Fetcher:
         self._retrying = Retrying(
             stop=stop_after_attempt(max_attempts),
             wait=wait_exponential(multiplier=0.1, max=2),
-            retry=retry_if_exception_type(
-                (httpx.HTTPStatusError, httpx.TransportError)
-            ),
+            retry=retry_if_exception(_should_retry),
             reraise=True,
         )
 

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,4 +1,5 @@
 import httpx
+import pytest
 
 from letras.source.fetcher import Fetcher, _parse_retry_after
 from letras.source.rate_limiter import RateLimiter
@@ -183,3 +184,20 @@ def test_fetcher_request_carries_compression_header() -> None:
     fetcher.artist_index()
     assert "br" in seen_headers["accept-encoding"]
     assert "gzip" in seen_headers["accept-encoding"]
+
+
+def test_fetcher_does_not_retry_4xx() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(404)
+
+    client = httpx.Client(
+        base_url="https://letras.test", transport=httpx.MockTransport(handler)
+    )
+    fetcher = Fetcher(client=client)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        fetcher.artist_index()
+    assert calls["n"] == 1  # 404 is permanent — not retried

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -129,3 +129,57 @@ def test_run_fetches_artists_concurrently() -> None:
     run(Fetcher(client=client), store, workers=4)
 
     assert state["max"] > 1  # multiple artist pages fetched at once
+
+
+def test_run_skips_artist_whose_page_errors() -> None:
+    index = (FIXTURES / "artist_index.html").read_text(encoding="utf-8")
+    artist = (FIXTURES / "artist_page.html").read_text(encoding="utf-8")
+    song = (FIXTURES / "song_page.html").read_text(encoding="utf-8")
+    dead = "1-igreja-batista-em-trindade"  # an index slug whose page 404s
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if "todosartistas" in path:
+            return httpx.Response(200, text=index)
+        if path.strip("/").count("/") == 0:  # artist page
+            if path.strip("/") == dead:
+                return httpx.Response(404)
+            return httpx.Response(200, text=artist)
+        return httpx.Response(200, text=song)
+
+    client = httpx.Client(
+        base_url="https://letras.test", transport=httpx.MockTransport(handler)
+    )
+    store = CorpusStore(":memory:")
+
+    run(Fetcher(client=client), store)  # full run must not abort on the 404
+
+    # 12 index artists, 1 dead (0 songs) + 11 with 10 songs each
+    assert len(list(store.iter_export())) == 110
+
+
+def test_run_skips_song_whose_page_errors() -> None:
+    index = (FIXTURES / "artist_index.html").read_text(encoding="utf-8")
+    artist = (FIXTURES / "artist_page.html").read_text(encoding="utf-8")
+    song = (FIXTURES / "song_page.html").read_text(encoding="utf-8")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if "todosartistas" in path:
+            return httpx.Response(200, text=index)
+        if path.strip("/").count("/") == 0:
+            return httpx.Response(200, text=artist)
+        if path.endswith("/44039/"):
+            return httpx.Response(404)  # one dead song page
+        return httpx.Response(200, text=song)
+
+    client = httpx.Client(
+        base_url="https://letras.test", transport=httpx.MockTransport(handler)
+    )
+    store = CorpusStore(":memory:")
+
+    run(Fetcher(client=client), store, only_slug="1-igreja-batista-em-trindade")
+
+    rows = list(store.iter_export())
+    assert len(rows) == 9  # 10 songs, the dead one skipped
+    assert all(s.slug != "44039" for _, s, _ in rows)


### PR DESCRIPTION
O seed completo (#9) abortou no primeiro artista cuja página dá 404 — e o índice de ~14k artistas tem slugs mortos (ex.: `ad-ministerio-belem-b-jacare`), então um seed frio morria em segundos.

**Conserto:**
- **pipeline:** erro HTTP (404/rede) numa página de artista ou música agora **pula o item** (como já fazia com `ParseError`), em vez de derrubar o run inteiro.
- **fetcher:** só re-tenta status transitório (429/5xx/timeout), não 4xx permanente — 404 falha rápido em vez de ser re-tentado 3x.

46 testes verdes (3 novos reproduzem a falha do CI).
