### PR TITLE
fix: eliminate HTTP/2 concurrency crash via async I/O

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
     "mypy>=1.10",
     "lxml-stubs>=0.5",
     "types-pyyaml>=6.0",
+    "pytest-asyncio>=1.4.0",
 ]
 
 [build-system]
@@ -62,3 +63,4 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"
+asyncio_mode = "auto"

--- a/src/letras/cli.py
+++ b/src/letras/cli.py
@@ -1,5 +1,6 @@
 """Command-line surface. Thin adapter over the pipeline and exporter."""
 
+import asyncio
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -51,18 +52,22 @@ def run(
     settings = Settings()
     fetcher = _build_fetcher(settings)
     store = CorpusStore(corpus)
-    try:
-        scrape(
-            fetcher,
-            store,
-            workers=settings.max_workers,
-            incremental=incremental,
-            only_slug=artist,
-            max_songs=max_songs,
-        )
-    finally:
-        fetcher.close()
-        store.close()
+
+    async def _scrape() -> None:
+        try:
+            await scrape(
+                fetcher,
+                store,
+                workers=settings.max_workers,
+                incremental=incremental,
+                only_slug=artist,
+                max_songs=max_songs,
+            )
+        finally:
+            await fetcher.aclose()
+            store.close()
+
+    asyncio.run(_scrape())
 
 
 @app.command()

--- a/src/letras/config.py
+++ b/src/letras/config.py
@@ -9,7 +9,8 @@ class Settings(BaseSettings):
     )
 
     base_url: str = "https://www.letras.mus.br"
-    # Sized so the rate limiter (below), not the worker count, governs throughput.
+    # Max requests in flight at once on the event loop. Sized so the rate
+    # limiter (below), not this cap, governs throughput.
     max_workers: int = 32
     max_attempts: int = 3
 
@@ -24,7 +25,7 @@ class Settings(BaseSettings):
     # Rate governing (token bucket + AIMD). ``requests_per_second`` is the
     # starting ceiling; the limiter backs off on 429/503 and recovers on
     # success, settling at the fastest sustainable rate. ``jitter`` desynchs
-    # bursts of worker threads. The legacy fixed ``delay`` is retained as a
+    # bursts of concurrent requests. The legacy fixed ``delay`` is retained as a
     # fallback only (0 = disabled; the limiter governs pacing instead).
     requests_per_second: float = 12.0
     min_requests_per_second: float = 1.0

--- a/src/letras/pipeline.py
+++ b/src/letras/pipeline.py
@@ -1,11 +1,13 @@
 """Orchestration: discover -> scrape -> store. One pipeline (ADR-0003).
 
-Fetching and parsing run concurrently across both artists and songs; SQLite
-writes stay on the calling thread, since the store holds a single connection.
-Full-vs-incremental is a selection predicate, not a separate runner.
+Fetching and parsing run concurrently on a single ``asyncio`` event loop, across
+both artists and songs; a ``Semaphore`` bounds how many requests are in flight
+at once. SQLite writes stay on the loop (the store holds one connection, and
+there is only one thread). Full-vs-incremental is a selection predicate, not a
+separate runner.
 """
 
-from concurrent.futures import ThreadPoolExecutor
+import asyncio
 
 import httpx
 
@@ -23,7 +25,7 @@ from letras.store.corpus_store import CorpusStore
 _BATCH = 500
 
 
-def run(
+async def run(
     fetcher: Fetcher,
     store: CorpusStore,
     *,
@@ -32,7 +34,7 @@ def run(
     only_slug: str | None = None,
     max_songs: int | None = None,
 ) -> None:
-    artists = parse_artist_index(fetcher.artist_index())
+    artists = parse_artist_index(await fetcher.artist_index())
     if only_slug is not None:
         artists = [a for a in artists if a.slug == only_slug]
 
@@ -43,12 +45,15 @@ def run(
         else {}
     )
 
+    sem = asyncio.Semaphore(workers)
+
     # Phase 1 (concurrent): fetch + parse each artist page into a flat work list.
-    def list_songs(artist: Artist) -> tuple[Artist, list[Song]]:
-        try:
-            html = fetcher.artist_page(artist.slug)
-        except httpx.HTTPError:
-            return artist, []  # dead/unreachable artist page -> skip it
+    async def list_songs(artist: Artist) -> tuple[Artist, list[Song]]:
+        async with sem:
+            try:
+                html = await fetcher.artist_page(artist.slug)
+            except httpx.HTTPError:
+                return artist, []  # dead/unreachable artist page -> skip it
         songs = parse_artist_songs(html)
         if incremental:
             songs = [s for s in songs if s.slug not in known[artist.slug]]
@@ -56,27 +61,39 @@ def run(
             songs = songs[:max_songs]
         return artist, songs
 
-    work: list[tuple[Artist, Song]] = []
-    with ThreadPoolExecutor(max_workers=workers) as pool:
-        for artist, songs in pool.map(list_songs, artists):
-            work.extend((artist, song) for song in songs)
+    listed: list[tuple[Artist, list[Song]]] = await asyncio.gather(
+        *(list_songs(artist) for artist in artists)
+    )
+    work: list[tuple[Artist, Song]] = [
+        (artist, song) for artist, songs in listed for song in songs
+    ]
 
-    # Phase 2 (concurrent): fetch + parse + label each song; store on this thread.
-    def scrape(item: tuple[Artist, Song]) -> tuple[Artist, Song, str, str] | None:
+    # Phase 2 (concurrent): fetch + parse + label each song; store on this loop.
+    async def scrape(
+        item: tuple[Artist, Song],
+    ) -> tuple[Artist, Song, str, str] | None:
         artist, song = item
+        async with sem:
+            try:
+                page = await fetcher.song_page(artist.slug, song.slug)
+            except httpx.HTTPError:
+                return None  # a dead page never aborts the run
         try:
-            content = parse_song(fetcher.song_page(artist.slug, song.slug))
-        except (httpx.HTTPError, ParseError):
-            return None  # a dead or malformed page never aborts the run
+            content = parse_song(page)
+        except ParseError:
+            return None  # a malformed page never aborts the run
         return artist, song, content, detect_language(content)
 
-    with ThreadPoolExecutor(max_workers=workers) as pool:
-        for start in range(0, len(work), _BATCH):
-            for result in pool.map(scrape, work[start : start + _BATCH]):
-                if result is None:
-                    continue
-                artist, song, content, language = result
-                song_id = store.upsert_song(song, artist_ids[artist.slug])
-                store.set_lyrics(
-                    song_id, content, language=language, char_count=len(content)
-                )
+    for start in range(0, len(work), _BATCH):
+        batch = work[start : start + _BATCH]
+        results: list[tuple[Artist, Song, str, str] | None] = await asyncio.gather(
+            *(scrape(item) for item in batch)
+        )
+        for result in results:
+            if result is None:
+                continue
+            artist, song, content, language = result
+            song_id = store.upsert_song(song, artist_ids[artist.slug])
+            store.set_lyrics(
+                song_id, content, language=language, char_count=len(content)
+            )

--- a/src/letras/source/fetcher.py
+++ b/src/letras/source/fetcher.py
@@ -6,8 +6,9 @@ source site:
 
 - **HTTP/2 + a warm keepalive pool.** Hundreds of thousands of requests ride a
   handful of long-lived, multiplexed connections instead of one socket per
-  request. Faster for us, and far gentler on the server (fewer connections,
-  fewer TLS handshakes).
+  request. The pipeline drives one ``asyncio`` event loop, so many in-flight
+  requests share those few connections safely (no thread races over the HTTP/2
+  connection state). Faster for us, and far gentler on the server.
 - **Compression** (gzip/brotli) negotiated via ``Accept-Encoding`` — the
   source serves brotli, roughly a 5-10x byte reduction on these pages.
 - **A shared token-bucket rate limiter with AIMD backoff** instead of a crude
@@ -19,11 +20,11 @@ The legacy fixed ``delay`` is kept as an optional extra pause; pacing is
 otherwise governed by the limiter.
 """
 
-import time
+import asyncio
 
 import httpx
 from tenacity import (
-    Retrying,
+    AsyncRetrying,
     retry_if_exception,
     stop_after_attempt,
     wait_exponential,
@@ -72,7 +73,7 @@ class Fetcher:
         self,
         base_url: str = _BASE_URL,
         *,
-        client: httpx.Client | None = None,
+        client: httpx.AsyncClient | None = None,
         delay: float = 0.0,
         max_attempts: int = 3,
         http2: bool = True,
@@ -81,7 +82,7 @@ class Fetcher:
         keepalive_expiry: float = 30.0,
         rate_limiter: RateLimiter | None = None,
     ) -> None:
-        self._client = client or httpx.Client(
+        self._client = client or httpx.AsyncClient(
             base_url=base_url,
             headers={
                 "User-Agent": _USER_AGENT,
@@ -98,14 +99,14 @@ class Fetcher:
         )
         self._delay = delay
         self._limiter = rate_limiter
-        self._retrying = Retrying(
+        self._retrying = AsyncRetrying(
             stop=stop_after_attempt(max_attempts),
             wait=wait_exponential(multiplier=0.1, max=2),
             retry=retry_if_exception(_should_retry),
             reraise=True,
         )
 
-    def _fetch(self, path: str) -> str:
+    async def _fetch(self, path: str) -> str:
         """One attempt: acquire a rate token, issue the request, and feed the
         outcome back to the limiter (backoff on throttle, ramp on success).
 
@@ -114,10 +115,10 @@ class Fetcher:
         retries the attempt at the now-reduced rate.
         """
         if self._limiter is not None:
-            self._limiter.acquire()
-        response = self._client.get(path)
+            await self._limiter.acquire()
+        response = await self._client.get(path)
         if response.status_code in _THROTTLE_CODES and self._limiter is not None:
-            self._limiter.on_throttled(
+            await self._limiter.on_throttled(
                 _parse_retry_after(response.headers.get("Retry-After"))
             )
         response.raise_for_status()  # throttle codes are 4xx/5xx -> raises here
@@ -125,20 +126,20 @@ class Fetcher:
             self._limiter.on_success()
         return response.text
 
-    def _get(self, path: str) -> str:
-        body: str = self._retrying(self._fetch, path)
+    async def _get(self, path: str) -> str:
+        body: str = await self._retrying(self._fetch, path)
         if self._delay:
-            time.sleep(self._delay)
+            await asyncio.sleep(self._delay)
         return body
 
-    def artist_index(self) -> str:
-        return self._get(_INDEX_PATH)
+    async def artist_index(self) -> str:
+        return await self._get(_INDEX_PATH)
 
-    def artist_page(self, slug: str) -> str:
-        return self._get(f"/{slug}/")
+    async def artist_page(self, slug: str) -> str:
+        return await self._get(f"/{slug}/")
 
-    def song_page(self, artist_slug: str, song_slug: str) -> str:
-        return self._get(f"/{artist_slug}/{song_slug}/")
+    async def song_page(self, artist_slug: str, song_slug: str) -> str:
+        return await self._get(f"/{artist_slug}/{song_slug}/")
 
-    def close(self) -> None:
-        self._client.close()
+    async def aclose(self) -> None:
+        await self._client.aclose()

--- a/src/letras/source/rate_limiter.py
+++ b/src/letras/source/rate_limiter.py
@@ -1,24 +1,31 @@
-"""A shared, thread-safe request-rate governor: token bucket + AIMD.
+"""A shared request-rate governor: token bucket + AIMD.
 
-The pipeline runs many worker threads against one ``Fetcher``. A precise
-global ceiling on requests/second is far gentler on the source than a crude
-per-request ``time.sleep`` (which scales with worker count and bursts on
-keepalive). This limiter is that ceiling, and it *adapts*: it backs off
-multiplicatively when the server pushes back (``429``/``503``, honoring
+The pipeline runs one event loop driving many concurrent requests through one
+``Fetcher``. A precise global ceiling on requests/second is far gentler on the
+source than a crude per-request ``sleep`` (which scales with concurrency and
+bursts on keepalive). This limiter is that ceiling, and it *adapts*: it backs
+off multiplicatively when the server pushes back (``429``/``503``, honoring
 ``Retry-After``) and recovers additively on sustained success (AIMD). The net
-effect is it automatically settles at the fastest rate the site tolerates,
-so the site never *needs* to ban us.
+effect is it automatically settles at the fastest rate the site tolerates, so
+the site never *needs* to ban us.
 
-Pure and testable: the monotonic clock and ``sleep`` are injected, so tests
-advance virtual time without blocking and never touch the network.
+Async and single-threaded: the limiter lives entirely on the event loop, so the
+token read-modify-write needs no lock (it never ``await``s mid-update, so
+coroutines can't interleave inside it). The monotonic clock and ``sleep`` are
+injected, so tests advance virtual time without blocking and never touch the
+network.
 """
 
 from __future__ import annotations
 
+import asyncio
 import random
-import threading
-import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
+from time import monotonic as _monotonic
+
+
+async def _sleep(seconds: float) -> None:
+    await asyncio.sleep(seconds)
 
 
 class RateLimiter:
@@ -32,8 +39,8 @@ class RateLimiter:
         increase_step: float = 0.5,
         backoff_factor: float = 0.5,
         jitter: float = 0.0,
-        monotonic: Callable[[], float] = time.monotonic,
-        sleep: Callable[[float], None] = time.sleep,
+        monotonic: Callable[[], float] = _monotonic,
+        sleep: Callable[[float], Awaitable[None]] = _sleep,
         rng: random.Random | None = None,
     ) -> None:
         if rate <= 0:
@@ -50,53 +57,48 @@ class RateLimiter:
         self._sleep = sleep
         self._rng = rng or random.Random()
         self._updated = monotonic()
-        self._lock = threading.Lock()
 
     @property
     def rate(self) -> float:
-        with self._lock:
-            return self._rate
+        return self._rate
 
-    def acquire(self) -> None:
+    async def acquire(self) -> None:
         """Block (cooperatively) until one request may proceed.
 
         Refills tokens for the elapsed time at the current rate, then either
         consumes a token or sleeps for exactly the shortfall. Optional jitter
-        adds a small random pause so a burst of threads does not fire in
+        adds a small random pause so a burst of coroutines does not fire in
         lockstep. The loop re-checks after sleeping because ``rate`` may have
         changed (a concurrent backoff) while waiting.
         """
         while True:
-            with self._lock:
-                now = self._monotonic()
-                elapsed = now - self._updated
-                self._updated = now
-                self._tokens = min(self._burst, self._tokens + elapsed * self._rate)
-                if self._tokens >= 1.0:
-                    self._tokens -= 1.0
-                    wait = 0.0
-                else:
-                    wait = (1.0 - self._tokens) / self._rate
+            now = self._monotonic()
+            elapsed = now - self._updated
+            self._updated = now
+            self._tokens = min(self._burst, self._tokens + elapsed * self._rate)
+            if self._tokens >= 1.0:
+                self._tokens -= 1.0
+                wait = 0.0
+            else:
+                wait = (1.0 - self._tokens) / self._rate
             if wait > 0.0:
-                self._sleep(wait)
+                await self._sleep(wait)
                 continue
             if self._jitter > 0.0:
-                self._sleep(self._rng.uniform(0.0, self._jitter))
+                await self._sleep(self._rng.uniform(0.0, self._jitter))
             return
 
     def on_success(self) -> None:
         """Additive increase: nudge the rate up toward the ceiling."""
-        with self._lock:
-            self._rate = min(self._max_rate, self._rate + self._increase_step)
+        self._rate = min(self._max_rate, self._rate + self._increase_step)
 
-    def on_throttled(self, retry_after: float | None) -> None:
+    async def on_throttled(self, retry_after: float | None) -> None:
         """Multiplicative decrease, honoring an explicit ``Retry-After``.
 
         Halves (by ``backoff_factor``) the sustained rate down to ``min_rate``
         and, if the server told us how long to wait, sleeps that long so the
         very next attempt does not immediately re-trip the throttle.
         """
-        with self._lock:
-            self._rate = max(self._min_rate, self._rate * self._backoff_factor)
+        self._rate = max(self._min_rate, self._rate * self._backoff_factor)
         if retry_after is not None and retry_after > 0.0:
-            self._sleep(retry_after)
+            await self._sleep(retry_after)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,7 +27,7 @@ def _fixture_fetcher() -> Fetcher:
             return httpx.Response(200, text=artist)
         return httpx.Response(200, text=song)
 
-    client = httpx.Client(
+    client = httpx.AsyncClient(
         base_url="https://letras.test", transport=httpx.MockTransport(handler)
     )
     return Fetcher(client=client)

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -5,24 +5,29 @@ from letras.source.fetcher import Fetcher, _parse_retry_after
 from letras.source.rate_limiter import RateLimiter
 
 
-def test_fetcher_builds_paths_and_returns_body() -> None:
+async def test_fetcher_builds_paths_and_returns_body() -> None:
     seen: list[str] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         seen.append(request.url.path)
         return httpx.Response(200, text=f"BODY {request.url.path}")
 
-    client = httpx.Client(
+    client = httpx.AsyncClient(
         base_url="https://letras.test", transport=httpx.MockTransport(handler)
     )
     fetcher = Fetcher(client=client)
 
-    assert fetcher.song_page("aline-barros", "44039") == "BODY /aline-barros/44039/"
-    assert fetcher.artist_index() == "BODY /estilos/gospelreligioso/todosartistas.html"
+    assert (
+        await fetcher.song_page("aline-barros", "44039") == "BODY /aline-barros/44039/"
+    )
+    assert (
+        await fetcher.artist_index()
+        == "BODY /estilos/gospelreligioso/todosartistas.html"
+    )
     assert "/aline-barros/44039/" in seen
 
 
-def test_fetcher_retries_transient_errors() -> None:
+async def test_fetcher_retries_transient_errors() -> None:
     calls = {"n": 0}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -31,12 +36,12 @@ def test_fetcher_retries_transient_errors() -> None:
             return httpx.Response(503)
         return httpx.Response(200, text="OK")
 
-    client = httpx.Client(
+    client = httpx.AsyncClient(
         base_url="https://letras.test", transport=httpx.MockTransport(handler)
     )
     fetcher = Fetcher(client=client)
 
-    assert fetcher.artist_index() == "OK"
+    assert await fetcher.artist_index() == "OK"
     assert calls["n"] == 2  # one failure, one retry
 
 
@@ -56,33 +61,33 @@ class _RecordingLimiter:
         self.successes = 0
         self.throttles: list[float | None] = []
 
-    def acquire(self) -> None:
+    async def acquire(self) -> None:
         self.acquired += 1
 
     def on_success(self) -> None:
         self.successes += 1
 
-    def on_throttled(self, retry_after: float | None) -> None:
+    async def on_throttled(self, retry_after: float | None) -> None:
         self.throttles.append(retry_after)
 
 
-def test_fetcher_acquires_a_token_and_signals_success() -> None:
+async def test_fetcher_acquires_a_token_and_signals_success() -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(200, text="OK")
 
     limiter = _RecordingLimiter()
-    client = httpx.Client(
+    client = httpx.AsyncClient(
         base_url="https://letras.test", transport=httpx.MockTransport(handler)
     )
     fetcher = Fetcher(client=client, rate_limiter=limiter)  # type: ignore[arg-type]
 
-    assert fetcher.artist_index() == "OK"
+    assert await fetcher.artist_index() == "OK"
     assert limiter.acquired == 1
     assert limiter.successes == 1
     assert limiter.throttles == []
 
 
-def test_fetcher_backs_off_on_429_with_retry_after() -> None:
+async def test_fetcher_backs_off_on_429_with_retry_after() -> None:
     calls = {"n": 0}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -92,19 +97,19 @@ def test_fetcher_backs_off_on_429_with_retry_after() -> None:
         return httpx.Response(200, text="OK")
 
     limiter = _RecordingLimiter()
-    client = httpx.Client(
+    client = httpx.AsyncClient(
         base_url="https://letras.test", transport=httpx.MockTransport(handler)
     )
     fetcher = Fetcher(client=client, rate_limiter=limiter)  # type: ignore[arg-type]
 
-    assert fetcher.artist_index() == "OK"  # retried after backing off
+    assert await fetcher.artist_index() == "OK"  # retried after backing off
     assert calls["n"] == 2
     assert limiter.throttles == [2.0]  # honored Retry-After
     assert limiter.acquired == 2  # a token per attempt
     assert limiter.successes == 1  # success only on the second attempt
 
 
-def test_fetcher_backs_off_on_503_without_retry_after() -> None:
+async def test_fetcher_backs_off_on_503_without_retry_after() -> None:
     calls = {"n": 0}
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -114,16 +119,16 @@ def test_fetcher_backs_off_on_503_without_retry_after() -> None:
         return httpx.Response(200, text="OK")
 
     limiter = _RecordingLimiter()
-    client = httpx.Client(
+    client = httpx.AsyncClient(
         base_url="https://letras.test", transport=httpx.MockTransport(handler)
     )
     fetcher = Fetcher(client=client, rate_limiter=limiter)  # type: ignore[arg-type]
 
-    assert fetcher.artist_index() == "OK"
+    assert await fetcher.artist_index() == "OK"
     assert limiter.throttles == [None]  # backoff via rate, no forced sleep
 
 
-def test_fetcher_real_limiter_backoff_reduces_rate() -> None:
+async def test_fetcher_real_limiter_backoff_reduces_rate() -> None:
     # End-to-end with a real RateLimiter (injected no-op clock so nothing
     # blocks): a 429 must drop the sustained rate.
     calls = {"n": 0}
@@ -135,25 +140,29 @@ def test_fetcher_real_limiter_backoff_reduces_rate() -> None:
         return httpx.Response(200, text="OK")
 
     now = {"t": 0.0}
+
+    async def fake_sleep(seconds: float) -> None:
+        now["t"] += seconds
+
     limiter = RateLimiter(
         rate=20.0,
         burst=10.0,
         backoff_factor=0.5,
         increase_step=0.0,  # isolate the backoff: no success-ramp confounder
         monotonic=lambda: now["t"],
-        sleep=lambda s: now.__setitem__("t", now["t"] + s),
+        sleep=fake_sleep,
     )
-    client = httpx.Client(
+    client = httpx.AsyncClient(
         base_url="https://letras.test", transport=httpx.MockTransport(handler)
     )
     fetcher = Fetcher(client=client, rate_limiter=limiter)
 
-    assert fetcher.artist_index() == "OK"
+    assert await fetcher.artist_index() == "OK"
     assert limiter.rate == 10.0  # halved by the 429, no ramp
     assert now["t"] == 1.0  # slept for Retry-After
 
 
-def test_fetcher_default_client_negotiates_compression() -> None:
+async def test_fetcher_default_client_negotiates_compression() -> None:
     # A default-constructed Fetcher builds its client to advertise br/gzip so
     # the source can compress (verified live: ~5-10x byte reduction).
     fetcher = Fetcher("https://letras.test")
@@ -162,10 +171,10 @@ def test_fetcher_default_client_negotiates_compression() -> None:
         assert "br" in accept_encoding
         assert "gzip" in accept_encoding
     finally:
-        fetcher.close()
+        await fetcher.aclose()
 
 
-def test_fetcher_request_carries_compression_header() -> None:
+async def test_fetcher_request_carries_compression_header() -> None:
     # And the negotiated header actually rides each outgoing request. We build
     # the client with the same headers the Fetcher uses plus a mock transport.
     seen_headers: dict[str, str] = {}
@@ -174,30 +183,30 @@ def test_fetcher_request_carries_compression_header() -> None:
         seen_headers.update(request.headers)
         return httpx.Response(200, text="OK")
 
-    client = httpx.Client(
+    client = httpx.AsyncClient(
         base_url="https://letras.test",
         headers={"Accept-Encoding": "gzip, deflate, br"},
         transport=httpx.MockTransport(handler),
     )
     fetcher = Fetcher(client=client)
 
-    fetcher.artist_index()
+    await fetcher.artist_index()
     assert "br" in seen_headers["accept-encoding"]
     assert "gzip" in seen_headers["accept-encoding"]
 
 
-def test_fetcher_does_not_retry_4xx() -> None:
+async def test_fetcher_does_not_retry_4xx() -> None:
     calls = {"n": 0}
 
     def handler(request: httpx.Request) -> httpx.Response:
         calls["n"] += 1
         return httpx.Response(404)
 
-    client = httpx.Client(
+    client = httpx.AsyncClient(
         base_url="https://letras.test", transport=httpx.MockTransport(handler)
     )
     fetcher = Fetcher(client=client)
 
     with pytest.raises(httpx.HTTPStatusError):
-        fetcher.artist_index()
+        await fetcher.artist_index()
     assert calls["n"] == 1  # 404 is permanent — not retried

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,5 +1,4 @@
-import threading
-import time
+import asyncio
 from pathlib import Path
 
 import httpx
@@ -24,16 +23,16 @@ def _fixture_fetcher() -> Fetcher:
             return httpx.Response(200, text=artist)
         return httpx.Response(200, text=song)  # /<artist>/<song>/
 
-    client = httpx.Client(
+    client = httpx.AsyncClient(
         base_url="https://letras.test", transport=httpx.MockTransport(handler)
     )
     return Fetcher(client=client)
 
 
-def test_run_populates_store_for_one_artist() -> None:
+async def test_run_populates_store_for_one_artist() -> None:
     store = CorpusStore(":memory:")
 
-    run(_fixture_fetcher(), store, only_slug="1-igreja-batista-em-trindade")
+    await run(_fixture_fetcher(), store, only_slug="1-igreja-batista-em-trindade")
 
     rows = list(store.iter_export())
     assert len(rows) == 10  # the artist fixture lists 10 songs
@@ -43,7 +42,7 @@ def test_run_populates_store_for_one_artist() -> None:
     assert {song.name for _, song, _ in rows} >= {"Consagração", "Jeová Jireh"}
 
 
-def test_incremental_run_skips_songs_already_in_corpus() -> None:
+async def test_incremental_run_skips_songs_already_in_corpus() -> None:
     index = (FIXTURES / "artist_index.html").read_text(encoding="utf-8")
     artist = (FIXTURES / "artist_page.html").read_text(encoding="utf-8")
     song = (FIXTURES / "song_page.html").read_text(encoding="utf-8")
@@ -58,21 +57,21 @@ def test_incremental_run_skips_songs_already_in_corpus() -> None:
         song_fetches.append(path)
         return httpx.Response(200, text=song)
 
-    client = httpx.Client(
+    client = httpx.AsyncClient(
         base_url="https://letras.test", transport=httpx.MockTransport(handler)
     )
     fetcher = Fetcher(client=client)
     store = CorpusStore(":memory:")
     slug = "1-igreja-batista-em-trindade"
 
-    run(fetcher, store, only_slug=slug)  # full: scrapes all 10 songs
+    await run(fetcher, store, only_slug=slug)  # full: scrapes all 10 songs
     assert len(song_fetches) == 10
 
-    run(fetcher, store, only_slug=slug, incremental=True)  # all known -> none
+    await run(fetcher, store, only_slug=slug, incremental=True)  # all known -> none
     assert len(song_fetches) == 10
 
 
-def test_run_skips_song_whose_lyrics_fail_to_parse() -> None:
+async def test_run_skips_song_whose_lyrics_fail_to_parse() -> None:
     index = (FIXTURES / "artist_index.html").read_text(encoding="utf-8")
     artist = (FIXTURES / "artist_page.html").read_text(encoding="utf-8")
     good_song = (FIXTURES / "song_page.html").read_text(encoding="utf-8")
@@ -88,50 +87,47 @@ def test_run_skips_song_whose_lyrics_fail_to_parse() -> None:
             return httpx.Response(200, text=broken_song)
         return httpx.Response(200, text=good_song)
 
-    client = httpx.Client(
+    client = httpx.AsyncClient(
         base_url="https://letras.test", transport=httpx.MockTransport(handler)
     )
     store = CorpusStore(":memory:")
 
-    run(Fetcher(client=client), store, only_slug="1-igreja-batista-em-trindade")
+    await run(Fetcher(client=client), store, only_slug="1-igreja-batista-em-trindade")
 
     rows = list(store.iter_export())
     assert len(rows) == 9  # 10 songs, the malformed one is skipped
     assert all(song.slug != "44039" for _, song, _ in rows)
 
 
-def test_run_fetches_artists_concurrently() -> None:
+async def test_run_fetches_artists_concurrently() -> None:
     index = (FIXTURES / "artist_index.html").read_text(encoding="utf-8")
     artist = (FIXTURES / "artist_page.html").read_text(encoding="utf-8")
     song = (FIXTURES / "song_page.html").read_text(encoding="utf-8")
-    lock = threading.Lock()
     state = {"in_flight": 0, "max": 0}
 
-    def handler(request: httpx.Request) -> httpx.Response:
+    async def handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
         if "todosartistas" in path:
             return httpx.Response(200, text=index)
         if path.strip("/").count("/") == 0:  # artist page
-            with lock:
-                state["in_flight"] += 1
-                state["max"] = max(state["max"], state["in_flight"])
-            time.sleep(0.03)
-            with lock:
-                state["in_flight"] -= 1
+            state["in_flight"] += 1
+            state["max"] = max(state["max"], state["in_flight"])
+            await asyncio.sleep(0.03)
+            state["in_flight"] -= 1
             return httpx.Response(200, text=artist)
         return httpx.Response(200, text=song)
 
-    client = httpx.Client(
+    client = httpx.AsyncClient(
         base_url="https://letras.test", transport=httpx.MockTransport(handler)
     )
     store = CorpusStore(":memory:")
 
-    run(Fetcher(client=client), store, workers=4)
+    await run(Fetcher(client=client), store, workers=4)
 
     assert state["max"] > 1  # multiple artist pages fetched at once
 
 
-def test_run_skips_artist_whose_page_errors() -> None:
+async def test_run_skips_artist_whose_page_errors() -> None:
     index = (FIXTURES / "artist_index.html").read_text(encoding="utf-8")
     artist = (FIXTURES / "artist_page.html").read_text(encoding="utf-8")
     song = (FIXTURES / "song_page.html").read_text(encoding="utf-8")
@@ -147,18 +143,18 @@ def test_run_skips_artist_whose_page_errors() -> None:
             return httpx.Response(200, text=artist)
         return httpx.Response(200, text=song)
 
-    client = httpx.Client(
+    client = httpx.AsyncClient(
         base_url="https://letras.test", transport=httpx.MockTransport(handler)
     )
     store = CorpusStore(":memory:")
 
-    run(Fetcher(client=client), store)  # full run must not abort on the 404
+    await run(Fetcher(client=client), store)  # full run must not abort on the 404
 
     # 12 index artists, 1 dead (0 songs) + 11 with 10 songs each
     assert len(list(store.iter_export())) == 110
 
 
-def test_run_skips_song_whose_page_errors() -> None:
+async def test_run_skips_song_whose_page_errors() -> None:
     index = (FIXTURES / "artist_index.html").read_text(encoding="utf-8")
     artist = (FIXTURES / "artist_page.html").read_text(encoding="utf-8")
     song = (FIXTURES / "song_page.html").read_text(encoding="utf-8")
@@ -173,12 +169,12 @@ def test_run_skips_song_whose_page_errors() -> None:
             return httpx.Response(404)  # one dead song page
         return httpx.Response(200, text=song)
 
-    client = httpx.Client(
+    client = httpx.AsyncClient(
         base_url="https://letras.test", transport=httpx.MockTransport(handler)
     )
     store = CorpusStore(":memory:")
 
-    run(Fetcher(client=client), store, only_slug="1-igreja-batista-em-trindade")
+    await run(Fetcher(client=client), store, only_slug="1-igreja-batista-em-trindade")
 
     rows = list(store.iter_export())
     assert len(rows) == 9  # 10 songs, the dead one skipped

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,33 +1,29 @@
 """Tests for the shared token-bucket + AIMD rate limiter.
 
-The limiter is a pure, thread-safe unit with no HTTP. To keep tests
-deterministic it accepts an injected monotonic clock and sleep function, so
-"time" advances explicitly and nothing actually blocks.
+The limiter is a pure async unit with no HTTP. To keep tests deterministic it
+accepts an injected monotonic clock and (async) sleep function, so "time"
+advances explicitly and nothing actually blocks.
 """
 
-import threading
+import asyncio
 import time
 
 from letras.source.rate_limiter import RateLimiter
 
 
 class FakeClock:
-    """A controllable, thread-safe monotonic clock; ``sleep`` advances it
-    instantly (read-modify-write is locked so the concurrency test is
-    deterministic)."""
+    """A controllable monotonic clock; ``sleep`` advances it instantly so the
+    async tests progress virtual time without ever blocking. Single-threaded
+    asyncio means no lock is needed."""
 
     def __init__(self) -> None:
         self.now = 0.0
-        self._lock = threading.Lock()
 
     def monotonic(self) -> float:
-        with self._lock:
-            return self.now
+        return self.now
 
-    def sleep(self, seconds: float) -> None:
-        # Sleeping advances virtual time without blocking the test.
-        with self._lock:
-            self.now += seconds
+    async def sleep(self, seconds: float) -> None:
+        self.now += seconds
 
 
 def _limiter(clock: FakeClock, **kw: float) -> RateLimiter:
@@ -46,45 +42,45 @@ def _limiter(clock: FakeClock, **kw: float) -> RateLimiter:
     )
 
 
-def test_first_acquire_is_immediate() -> None:
+async def test_first_acquire_is_immediate() -> None:
     clock = FakeClock()
     limiter = _limiter(clock, burst=1.0)
 
-    limiter.acquire()
+    await limiter.acquire()
 
     assert clock.now == 0.0  # one burst token available at start
 
 
-def test_acquire_blocks_until_a_token_refills() -> None:
+async def test_acquire_blocks_until_a_token_refills() -> None:
     clock = FakeClock()
     limiter = _limiter(clock, rate=10.0, burst=1.0)  # 1 token / 0.1s
 
-    limiter.acquire()  # consumes the initial token
-    limiter.acquire()  # must wait 0.1s for the next
+    await limiter.acquire()  # consumes the initial token
+    await limiter.acquire()  # must wait 0.1s for the next
 
     assert clock.now == 0.1
 
 
-def test_rate_decreases_multiplicatively_on_backoff() -> None:
+async def test_rate_decreases_multiplicatively_on_backoff() -> None:
     clock = FakeClock()
     limiter = _limiter(clock, rate=20.0, backoff_factor=0.5)
 
-    limiter.on_throttled(retry_after=None)
+    await limiter.on_throttled(retry_after=None)
 
     assert limiter.rate == 10.0  # halved
 
 
-def test_backoff_respects_min_rate_floor() -> None:
+async def test_backoff_respects_min_rate_floor() -> None:
     clock = FakeClock()
     limiter = _limiter(clock, rate=2.0, min_rate=1.0, backoff_factor=0.5)
 
-    limiter.on_throttled(retry_after=None)
-    limiter.on_throttled(retry_after=None)
+    await limiter.on_throttled(retry_after=None)
+    await limiter.on_throttled(retry_after=None)
 
     assert limiter.rate == 1.0  # clamped to the floor, not 0.5
 
 
-def test_success_increases_rate_additively_toward_ceiling() -> None:
+async def test_success_increases_rate_additively_toward_ceiling() -> None:
     clock = FakeClock()
     limiter = _limiter(clock, rate=10.0, max_rate=12.0, increase_step=1.0)
 
@@ -96,48 +92,36 @@ def test_success_increases_rate_additively_toward_ceiling() -> None:
     assert limiter.rate == 12.0  # never exceeds the ceiling
 
 
-def test_throttle_with_retry_after_sleeps_for_that_duration() -> None:
+async def test_throttle_with_retry_after_sleeps_for_that_duration() -> None:
     clock = FakeClock()
     limiter = _limiter(clock, rate=10.0)
 
-    limiter.on_throttled(retry_after=3.0)
+    await limiter.on_throttled(retry_after=3.0)
 
     assert clock.now == 3.0  # honored the server's Retry-After
 
 
-def test_throttle_without_retry_after_does_not_sleep() -> None:
+async def test_throttle_without_retry_after_does_not_sleep() -> None:
     clock = FakeClock()
     limiter = _limiter(clock, rate=10.0)
 
-    limiter.on_throttled(retry_after=None)
+    await limiter.on_throttled(retry_after=None)
 
     assert clock.now == 0.0  # backoff is via the rate, not a forced sleep
 
 
-def test_acquire_is_threadsafe_and_does_not_over_issue() -> None:
+async def test_acquire_is_concurrency_safe_and_does_not_over_issue() -> None:
     # Concurrency invariant on a real (short) wall clock: with a high rate and
-    # generous burst, many threads each acquiring once must all complete and
+    # generous burst, many coroutines each acquiring once must all complete and
     # the bucket must never hand out more than it should for the elapsed time.
     # Real time + bounded work => fast and cannot livelock.
     limiter = RateLimiter(rate=1000.0, burst=20.0, jitter=0.0)
     n = 40
-    counter = {"done": 0}
-    lock = threading.Lock()
-
-    def worker() -> None:
-        limiter.acquire()
-        with lock:
-            counter["done"] += 1
 
     start = time.monotonic()
-    threads = [threading.Thread(target=worker) for _ in range(n)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join(timeout=5.0)
+    await asyncio.gather(*(limiter.acquire() for _ in range(n)))
     elapsed = time.monotonic() - start
 
-    assert counter["done"] == n  # every thread got through; no deadlock
     # n tokens cost at least (n - burst) / rate seconds of refill (the burst is
     # free); the limiter must not have issued them faster than the rate allows.
     assert elapsed >= (n - 20) / 1000.0 - 1e-3

--- a/uv.lock
+++ b/uv.lock
@@ -422,6 +422,7 @@ dev = [
     { name = "lxml-stubs" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "types-pyyaml" },
@@ -446,6 +447,7 @@ dev = [
     { name = "lxml-stubs", specifier = ">=0.5" },
     { name = "mypy", specifier = ">=1.10" },
     { name = "pytest", specifier = ">=8.2" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "ruff", specifier = ">=0.5" },
     { name = "types-pyyaml", specifier = ">=6.0" },
@@ -868,6 +870,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

The **Full Scraping** workflow (`workflow_dispatch`) aborted with:

```
RuntimeError: deque mutated during iteration
```

deep in `hpack/table.py` — HTTP/2's header-compression state.

## Root cause

`Fetcher` held **one shared `httpx.Client` with `http2=True`**, and the
pipeline called it from up to 32 threads via a `ThreadPoolExecutor`. HTTP/2
multiplexes concurrent requests over a few connections, each with a single
HPACK dynamic table (a `collections.deque`). httpx's HTTP/2 transport is **not
thread-safe**, so one thread mutated that deque while another iterated it. The
escaping `RuntimeError` (not an `httpx.HTTPError`) bypassed the per-page
skip handlers and killed the whole run.

## Fix

Move scraping onto a **single `asyncio` event loop** — the model where HTTP/2
multiplexing is actually safe *and* delivers its benefit (many in-flight
requests over a few connections):

- `Fetcher` → `httpx.AsyncClient` + tenacity `AsyncRetrying`; `close` → `aclose`.
- `RateLimiter` → async; its token read-modify-write never `await`s, so on a
  single-threaded loop it needs no lock.
- `pipeline.run` → `asyncio.gather` bounded by a `Semaphore` instead of the
  thread pool; SQLite writes stay on the loop (one connection, one thread).
- `cli.run` → drives the loop with `asyncio.run`.

One thread means no thread races over the HTTP/2 connection state.

## Verification

- Full suite green (`46 passed`), `ruff check`, `ruff format --check`, `mypy`
  (strict) all clean.
- The pipeline concurrency test now asserts multiple requests in flight over a
  single `AsyncClient`.
- Live concurrent scrape against letras.mus.br (one artist, 30 songs over
  HTTP/2): exit 0, 30 lyrics collected, no crash.

> Note: **Full Scraping** is a manual `workflow_dispatch` that publishes a
> Release, so it isn't triggered by this PR. The **Tests** workflow runs here;
> re-dispatch Full Scraping after merge to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
