### PR TITLE
fix: skip pages with control chars or unparseable HTML

### DIFF
--- a/src/letras/pipeline.py
+++ b/src/letras/pipeline.py
@@ -54,7 +54,10 @@ async def run(
                 html = await fetcher.artist_page(artist.slug)
             except httpx.HTTPError:
                 return artist, []  # dead/unreachable artist page -> skip it
-        songs = parse_artist_songs(html)
+        try:
+            songs = parse_artist_songs(html)
+        except ParseError:
+            return artist, []  # unparseable artist page -> skip it
         if incremental:
             songs = [s for s in songs if s.slug not in known[artist.slug]]
         if max_songs is not None:

--- a/src/letras/source/parser.py
+++ b/src/letras/source/parser.py
@@ -1,13 +1,35 @@
 """Pure HTML → domain parsing. All site-specific selectors live here."""
 
+import re
+
 from lxml import html as lxml_html
-from lxml.etree import _Element
+from lxml.etree import LxmlError, _Element
 
 from letras.domain.entities import Artist, Song
 
 
 class ParseError(Exception):
     """Raised when the page structure does not match expectations (site drift)."""
+
+
+# Characters libxml2 refuses inside a text node — everything XML 1.0 forbids bar
+# tab/newline/carriage-return. Some live lyric pages carry a stray control byte;
+# strip it so the page still parses and the byte never reaches the corpus.
+_CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
+
+
+def _tree(html: str) -> _Element:
+    """Parse HTML to an element tree, normalizing failures to ``ParseError``.
+
+    Strips XML-incompatible control characters first, then turns lxml's own
+    parse failures (e.g. an empty body) into ``ParseError`` so every parser
+    obeys one contract: return a value, or raise ``ParseError`` for callers to
+    skip — no raw lxml/``ValueError`` ever leaks out to abort a run.
+    """
+    try:
+        return lxml_html.fromstring(_CONTROL_CHARS.sub("", html))
+    except LxmlError as exc:
+        raise ParseError("unparseable HTML") from exc
 
 
 def _collapsed_text(element: _Element) -> str:
@@ -21,7 +43,7 @@ def parse_song(html: str) -> str:
     Within ``div.lyric-original`` each ``<p>`` is a stanza and each ``<br>`` a
     line break; stanzas are joined by a blank line.
     """
-    tree = lxml_html.fromstring(html)
+    tree = _tree(html)
     containers = tree.cssselect("div.lyric-original")
     if not containers:
         raise ParseError("no div.lyric-original element found")
@@ -38,7 +60,7 @@ def parse_song(html: str) -> str:
 
 def parse_artist_songs(html: str) -> list[Song]:
     """Extract an artist's songs (name + slug) from their page."""
-    tree = lxml_html.fromstring(html)
+    tree = _tree(html)
     songs = []
     for anchor in tree.cssselect("a.songList-table-songName"):
         href = anchor.get("href") or ""
@@ -49,7 +71,7 @@ def parse_artist_songs(html: str) -> list[Song]:
 
 def parse_artist_index(html: str) -> list[Artist]:
     """Extract all artists (name + slug) from the gospel index fragment."""
-    tree = lxml_html.fromstring(html)
+    tree = _tree(html)
     artists = []
     for anchor in tree.cssselect("ul.cnt-list a"):
         href = anchor.get("href") or ""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -68,3 +68,19 @@ def test_parse_song_raises_on_missing_lyrics_element() -> None:
 def test_parse_artist_index_raises_when_no_artists_found() -> None:
     with pytest.raises(ParseError):
         parse_artist_index("<html><body><p>no artist list here</p></body></html>")
+
+
+def test_parse_song_strips_control_characters() -> None:
+    # Some live song pages carry a stray control byte in the lyric. It must not
+    # crash the parse (libxml2 rejects control chars in text nodes) and must not
+    # leak into the corpus; the lyric is salvaged.
+    html = '<div class="lyric-original"><p>Aleluia<br>Glória\x07\x00</p></div>'
+
+    assert parse_song(html) == "Aleluia\nGlória"
+
+
+def test_parse_song_raises_parse_error_on_empty_html() -> None:
+    # An empty/blank body makes lxml raise its own ParserError; the parser must
+    # normalize that to ParseError so the pipeline can skip the page.
+    with pytest.raises(ParseError):
+        parse_song("")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -154,6 +154,33 @@ async def test_run_skips_artist_whose_page_errors() -> None:
     assert len(list(store.iter_export())) == 110
 
 
+async def test_run_skips_artist_whose_page_is_malformed() -> None:
+    index = (FIXTURES / "artist_index.html").read_text(encoding="utf-8")
+    artist = (FIXTURES / "artist_page.html").read_text(encoding="utf-8")
+    song = (FIXTURES / "song_page.html").read_text(encoding="utf-8")
+    dead = "1-igreja-batista-em-trindade"  # 200 OK but an empty/unparseable body
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if "todosartistas" in path:
+            return httpx.Response(200, text=index)
+        if path.strip("/").count("/") == 0:  # artist page
+            if path.strip("/") == dead:
+                return httpx.Response(200, text="")  # unparseable -> ParseError
+            return httpx.Response(200, text=artist)
+        return httpx.Response(200, text=song)
+
+    client = httpx.AsyncClient(
+        base_url="https://letras.test", transport=httpx.MockTransport(handler)
+    )
+    store = CorpusStore(":memory:")
+
+    await run(Fetcher(client=client), store)  # must not abort on the bad page
+
+    # 12 index artists, 1 unparseable (0 songs) + 11 with 10 songs each
+    assert len(list(store.iter_export())) == 110
+
+
 async def test_run_skips_song_whose_page_errors() -> None:
     index = (FIXTURES / "artist_index.html").read_text(encoding="utf-8")
     artist = (FIXTURES / "artist_page.html").read_text(encoding="utf-8")


### PR DESCRIPTION
## Problem

With the HTTP/2 async fix (#12) in place, the full scrape ran 5× longer
(~10 min vs ~2 min) and then aborted with:

```
ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL
bytes or control characters
```

at `parser.py` (`br.tail = "\n" + (br.tail or "")`). A song page's lyrics
carried a stray control byte; lxml rejects those when building text nodes.
The `ValueError` is **not** a `ParseError`, so it slipped past the pipeline's
per-page guard and killed the whole run — the same "one bad page aborts
everything" shape as the original crash.

## Fix

Give every parser one contract — **return a value, or raise `ParseError`**:

- Strip XML-incompatible control characters before parsing (a shared
  `_tree()` helper), **salvaging** the lyric instead of dropping the song.
- Normalize lxml's own errors (e.g. an empty body → `ParserError`) to
  `ParseError`, so no raw lxml/`ValueError` ever leaks out.

Harden the pipeline to match: `list_songs` now skips an artist whose page
raises `ParseError`, mirroring how it already skips dead (404) pages. One
bad page never aborts the run.

## Verification

- Full suite green (`49 passed`), `ruff check`, `ruff format --check`,
  `mypy` (strict) all clean.
- New tests: control bytes are stripped and the lyric salvaged; an empty
  body raises `ParseError`; a run with one unparseable artist page completes
  and skips only that artist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
