### PR TITLE
fix: bound release notes and de-duplicate zip names

### DIFF
--- a/src/letras/release/exporter.py
+++ b/src/letras/release/exporter.py
@@ -3,7 +3,6 @@ per-song .txt ZIP of admitted songs, and notes (ADR-0002)."""
 
 import shutil
 import zipfile
-from collections import Counter
 from pathlib import Path
 
 from letras.domain.admission import admit
@@ -19,7 +18,9 @@ def export_release(
     date: str,
     policy: AdmissionPolicy,
 ) -> None:
+    scraped = 0
     for row in store.iter_for_admission():
+        scraped += 1
         song_id, artist_name, song_name, content, language = row
         verdict = admit(
             artist_name=artist_name,
@@ -34,26 +35,63 @@ def export_release(
     shutil.copyfile(db_path, out_dir / "corpus.db")
 
     rows = list(store.iter_admitted())
+    used_names: set[str] = set()
     with zipfile.ZipFile(out_dir / "letras.zip", "w", zipfile.ZIP_DEFLATED) as archive:
         for artist, song, content in rows:
-            filename = f"{artist.name} - {song.name}.txt".replace("/", "_")
+            filename = _unique_filename(artist, song, used_names)
+            used_names.add(filename)
             archive.writestr(filename, f"{song.name}\n{artist.name}\n\n{content}")
 
     (out_dir / "RELEASE_NOTES.md").write_text(
-        _render_notes(rows, date), encoding="utf-8"
+        _render_notes(rows, date, scraped), encoding="utf-8"
     )
 
 
-def _render_notes(rows: list[tuple[Artist, Song, str]], date: str) -> str:
-    songs_per_artist: Counter[str] = Counter(artist.name for artist, _, _ in rows)
-    lines = [
-        f"# Letras Gospel — {date}",
-        "",
-        f"{len(rows)} songs from {len(songs_per_artist)} artists.",
-        "",
-        "## Artists",
-    ]
-    lines += [
-        f"- {name} ({count} songs)" for name, count in songs_per_artist.most_common()
-    ]
-    return "\n".join(lines) + "\n"
+def _unique_filename(artist: Artist, song: Song, used: set[str]) -> str:
+    """A ZIP-safe ``Artist - Song.txt`` name, disambiguated by the (globally
+    unique) song slug if two songs would otherwise collide — so no song is
+    silently overwritten in the archive."""
+    base = f"{artist.name} - {song.name}"
+    name = f"{base}.txt".replace("/", "_")
+    suffix = 0
+    while name in used:
+        suffix += 1
+        tag = song.slug if suffix == 1 else f"{song.slug}-{suffix}"
+        name = f"{base} ({tag}).txt".replace("/", "_")
+    return name
+
+
+def _thousands(value: int) -> str:
+    """Format an integer with Brazilian thousands separators (1234 -> '1.234')."""
+    return f"{value:,}".replace(",", ".")
+
+
+def _render_notes(rows: list[tuple[Artist, Song, str]], date: str, scraped: int) -> str:
+    """Concise, bounded release notes (in Portuguese — the one audience-facing
+    artifact). The full per-artist breakdown lives in ``corpus.db`` (queryable);
+    listing every artist here would blow past GitHub's 125,000-character
+    release-body limit."""
+    artists = len({artist.slug for artist, _, _ in rows})
+    return (
+        "\n".join(
+            [
+                f"# Letras Gospel — {date}",
+                "",
+                "Letras gospel em português coletadas de letras.mus.br e "
+                "curadas para o corpus.",
+                "",
+                "| Métrica | Total |",
+                "|---|---|",
+                f"| Músicas (admitidas) | {_thousands(len(rows))} |",
+                f"| Artistas | {_thousands(artists)} |",
+                f"| Coletadas (brutas) | {_thousands(scraped)} |",
+                f"| Gerado em | {date} |",
+                "",
+                "## Downloads",
+                "- `corpus.db` — corpus completo em SQLite "
+                "(artists, songs, lyrics, language)",
+                "- `letras.zip` — um `.txt` por música (`Artista - Música.txt`)",
+            ]
+        )
+        + "\n"
+    )

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from letras.domain.entities import Artist, Song
 from letras.domain.policy import load_policy
-from letras.release.exporter import export_release
+from letras.release.exporter import _render_notes, export_release
 from letras.store.corpus_store import CorpusStore
 
 GOOD = "Louvarei ao Senhor de todo o meu coração e exaltarei o Teu nome " * 4
@@ -28,4 +28,46 @@ def test_export_release_includes_only_admitted_songs(tmp_path: Path) -> None:
     assert "Aline Barros - Short.txt" not in names
 
     notes = (out / "RELEASE_NOTES.md").read_text(encoding="utf-8")
-    assert "1 songs from 1 artists" in notes
+    assert "| Músicas (admitidas) | 1 |" in notes
+    assert "| Artistas | 1 |" in notes
+    assert "| Coletadas (brutas) | 2 |" in notes  # Consagração ok, Short rejeitada
+
+
+def test_render_notes_is_bounded_and_omits_per_artist_list() -> None:
+    # GitHub rejects a release body over 125,000 chars. The corpus has
+    # thousands of artists, so the notes must NOT list them one by one.
+    rows = [
+        (
+            Artist(name=f"Artista {i:05d}", slug=f"a{i}"),
+            Song(name=f"Canção {i}", slug=f"s{i}"),
+            "lyric",
+        )
+        for i in range(8000)
+    ]
+
+    notes = _render_notes(rows, "20260616", scraped=9000)
+
+    assert len(notes) < 125_000
+    assert "Artista 04000" not in notes  # individual artists are not listed
+    assert "| Músicas (admitidas) | 8.000 |" in notes  # PT thousands separator
+    assert "| Coletadas (brutas) | 9.000 |" in notes
+
+
+def test_export_zip_disambiguates_colliding_filenames(tmp_path: Path) -> None:
+    # Two distinct songs can map to the same "Artist - Song.txt"; neither may be
+    # silently dropped from the archive.
+    db_path = tmp_path / "corpus.db"
+    store = CorpusStore(db_path)
+    artist_id = store.upsert_artist(Artist(name="Fulano", slug="fulano"))
+    one = store.upsert_song(Song(name="Igual", slug="v1"), artist_id)
+    store.set_lyrics(one, GOOD, "pt", len(GOOD))
+    two = store.upsert_song(Song(name="Igual", slug="v2"), artist_id)
+    store.set_lyrics(two, GOOD + " distinta", "pt", len(GOOD) + 9)
+    out = tmp_path / "dist"
+
+    export_release(store, db_path, out, date="20260616", policy=load_policy())
+
+    with zipfile.ZipFile(out / "letras.zip") as archive:
+        names = archive.namelist()
+    assert len(names) == 2  # both songs written
+    assert len(set(names)) == 2  # under distinct names — no silent overwrite


### PR DESCRIPTION
## Problem

After the scrape (#12) and parser (#13) fixes, the full run finally
completed the scrape (2h28m) **and** the export — then the **Publish
release** step failed:

```
HTTP 422: Validation Failed … body is too long (maximum is 125000 characters)
```

The release notes listed every artist; for the full corpus that body
exceeds GitHub's 125,000-char cap. The export logs also showed many
`Duplicate name: '… .txt'` warnings — colliding `Artist - Song.txt` names
silently overwriting each other in `letras.zip`.

## Fix

- **Bounded release notes.** Rewrite the notes as a concise, constant-size
  summary — counts, curation ratio (admitted vs scraped), downloads — in
  **Portuguese** (the release page is the one audience-facing artifact;
  code/commits/internal docs stay English). The exhaustive per-artist
  breakdown stays queryable in `corpus.db`, so the body can never hit the
  cap again.
- **Lossless ZIP.** De-duplicate colliding song filenames using the
  globally-unique song slug, so no song is dropped from the archive.

## Verification

- Full suite green (`51 passed`), `ruff check`, `ruff format --check`,
  `mypy` (strict) all clean.
- New tests: notes stay < 125,000 chars and omit the per-artist list even
  for 8k artists; two songs that map to the same filename are both written
  under distinct names.
- Real `letras export` produces a ~380-byte `RELEASE_NOTES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
