### PR TITLE
Rework release outputs (OpenLyrics) and README for projection use

### DIFF
--- a/.github/workflows/full.yaml
+++ b/.github/workflows/full.yaml
@@ -40,8 +40,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          date=$(date +'%Y%m%d')
-          gh release create "v${date}.${{ github.run_number }}" \
-            dist/corpus.db dist/letras.zip dist/RELEASE_NOTES.md \
-            --title "Letras ${date} (full)" \
+          stamp=$(date -u +'%Y%m%d')                          # sortable tag
+          title_date="${stamp:6:2}${stamp:4:2}${stamp:0:4}"   # DDMMYYYY (BR)
+          gh release create "v${stamp}.${{ github.run_number }}" \
+            dist/corpus.db dist/letras-txt.zip dist/letras-openlyrics.zip \
+            --title "Letras ${title_date}" \
             --notes-file dist/RELEASE_NOTES.md

--- a/.github/workflows/incremental.yaml
+++ b/.github/workflows/incremental.yaml
@@ -37,8 +37,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          date=$(date +'%Y%m%d')
-          gh release create "v${date}.${{ github.run_number }}" \
-            dist/corpus.db dist/letras.zip dist/RELEASE_NOTES.md \
-            --title "Letras ${date}" \
+          stamp=$(date -u +'%Y%m%d')                          # sortable tag
+          title_date="${stamp:6:2}${stamp:4:2}${stamp:0:4}"   # DDMMYYYY (BR)
+          gh release create "v${stamp}.${{ github.run_number }}" \
+            dist/corpus.db dist/letras-txt.zip dist/letras-openlyrics.zip \
+            --title "Letras ${title_date}" \
             --notes-file dist/RELEASE_NOTES.md

--- a/README.md
+++ b/README.md
@@ -2,36 +2,30 @@
 <div align="center">
     <img src="https://img.shields.io/github/v/tag/damarals/letras?color=success&label=" alt="Latest Tag" />
     <img src="https://img.shields.io/github/last-commit/damarals/letras/main?path=README.md&label=%C3%BAltima%20atualiza%C3%A7%C3%A3o&color=blue" alt="Última atualização" />
-    <img src="https://img.shields.io/github/actions/workflow/status/damarals/letras/test.yaml?label=testes" alt="Testes" />
 </div>
 <br />
-<div align="center"><strong>Um corpus de letras gospel em português</strong></div>
-<div align="center">Letras evangélicas curadas, em banco SQLite e arquivos de texto,<br/> atualizadas toda semana.</div>
+<div align="center"><strong>Uma coletânea de milhares de letras gospel em português</strong></div>
+<div align="center">Em formatos abertos (.txt e .xml), pronta para uso no OpenLP, Quelea ou em qualquer outra aplicação.</div>
+<br />
+<div align="center">
+  <a href="https://github.com/damarals/letras/releases/latest/download/letras-txt.zip"><img src="https://custom-icon-badges.demolab.com/badge/Baixar-Letras%20(.txt)-F25278?style=for-the-badge&logo=download&logoColor=white" alt="Letras (.txt)" /></a>
+  <a href="https://github.com/damarals/letras/releases/latest/download/letras-openlyrics.zip"><img src="https://custom-icon-badges.demolab.com/badge/Baixar-Letras%20(.xml)-F25278?style=for-the-badge&logo=download&logoColor=white" alt="Letras (.xml)" /></a>
+</div>
 <br />
 <div align="center">
   <sub>Desenvolvido por <a href="https://github.com/damarals">Daniel Amaral</a> 👨‍💻</sub>
 </div>
 <br />
 
-## Download
-
-Baixe na última [release](https://github.com/damarals/letras/releases/latest):
-
-<div align="center">
-  <a href="https://github.com/damarals/letras/releases/latest/download/letras.zip"><img src="https://custom-icon-badges.demolab.com/badge/Baixar-Letras%20(.zip)-F25278?style=for-the-badge&logo=download&logoColor=white" alt="Letras (.zip)" /></a>
-  <a href="https://github.com/damarals/letras/releases/latest/download/corpus.db"><img src="https://custom-icon-badges.demolab.com/badge/Baixar-SQLite-F25278?style=for-the-badge&logo=download&logoColor=white" alt="SQLite" /></a>
-</div>
-
 ## Conteúdo
 
-- **SQLite** (`corpus.db`) — tabelas `artists`, `songs` e `lyrics`. O banco guarda **tudo o que foi coletado**; o corpus curado é uma consulta:
+- **Textos** (`letras-txt.zip`): um arquivo `<Artista> - <Música>.txt` por música aprovada. Cada um traz título, artista, uma linha em branco e a letra.
+- **OpenLyrics** (`letras-openlyrics.zip`): um `.xml` por música no formato [OpenLyrics](https://docs.openlyrics.org/). O OpenLP e o Quelea importam direto, com título e autor já nos campos certos.
+- **SQLite** (`corpus.db`): tabelas `artists`, `songs` e `lyrics`. O banco guarda **tudo o que foi coletado**, inclusive o que a curadoria descartou. Os dois `.zip` trazem só as letras aprovadas, o resultado desta consulta:
 
   ```sql
   SELECT * FROM lyrics WHERE admitted = 1;
   ```
-
-- **Textos** (`letras.zip`) — um arquivo `<Artista> - <Música>.txt` por música admitida.
-- **RELEASE_NOTES.md** — resumo da release (quantas músicas, de quantos artistas).
 
 ## Curadoria
 
@@ -45,19 +39,11 @@ Toolkit em Python (com [uv](https://docs.astral.sh/uv/)). Sem banco de dados, se
 uv sync
 uv run letras run --incremental   # semanal: coleta só músicas novas
 uv run letras run                 # reconciliação completa (recoleta tudo)
-uv run letras export --out dist   # gera corpus.db + letras.zip + notas
+uv run letras export --out dist   # gera corpus.db, os .zip e as notas
 ```
 
 Configurável por variáveis `LETRAS_` (ex.: `LETRAS_DELAY`, `LETRAS_MAX_WORKERS`).
 
-## Atualizações
-
-Toda semana o GitHub Actions coleta as músicas novas, aplica a curadoria e publica uma release com o banco, os textos e as notas.
-
 ## Licença
 
 MIT. Veja [LICENSE](LICENSE).
-
-## Aviso Legal
-
-Ferramenta para fins educacionais. As letras são propriedade de seus respectivos donos e foram coletadas de fontes publicamente disponíveis.

--- a/src/letras/release/exporter.py
+++ b/src/letras/release/exporter.py
@@ -140,8 +140,7 @@ def _render_notes(rows: list[tuple[Artist, Song, str]], date: str, scraped: int)
             [
                 "# Letras gospel em português",
                 "",
-                "Milhares de letras de músicas evangélicas coletadas de "
-                "letras.mus.br.",
+                "Milhares de letras de músicas evangélicas coletadas de letras.mus.br.",
                 "",
                 "| Métrica | Total |",
                 "|---|---|",

--- a/src/letras/release/exporter.py
+++ b/src/letras/release/exporter.py
@@ -1,8 +1,11 @@
 """Build a Release from the corpus: stamp Admission, then emit the .db, a
-per-song .txt ZIP of admitted songs, and notes (ADR-0002)."""
+per-song .txt ZIP, a per-song OpenLyrics .xml ZIP, and notes (ADR-0002)."""
 
+import re
 import shutil
+import xml.etree.ElementTree as ET
 import zipfile
+from datetime import datetime
 from pathlib import Path
 
 from letras.domain.admission import admit
@@ -36,34 +39,94 @@ def export_release(
 
     rows = list(store.iter_admitted())
     used_names: set[str] = set()
-    with zipfile.ZipFile(out_dir / "letras.zip", "w", zipfile.ZIP_DEFLATED) as archive:
+    with zipfile.ZipFile(
+        out_dir / "letras-txt.zip", "w", zipfile.ZIP_DEFLATED
+    ) as archive:
         for artist, song, content in rows:
             filename = _unique_filename(artist, song, used_names)
             used_names.add(filename)
             archive.writestr(filename, f"{song.name}\n{artist.name}\n\n{content}")
+
+    xml_names: set[str] = set()
+    with zipfile.ZipFile(
+        out_dir / "letras-openlyrics.zip", "w", zipfile.ZIP_DEFLATED
+    ) as archive:
+        for artist, song, content in rows:
+            filename = _unique_filename(artist, song, xml_names, "xml")
+            xml_names.add(filename)
+            archive.writestr(filename, _render_openlyrics(artist, song, content))
 
     (out_dir / "RELEASE_NOTES.md").write_text(
         _render_notes(rows, date, scraped), encoding="utf-8"
     )
 
 
-def _unique_filename(artist: Artist, song: Song, used: set[str]) -> str:
-    """A ZIP-safe ``Artist - Song.txt`` name, disambiguated by the (globally
+def _unique_filename(
+    artist: Artist, song: Song, used: set[str], ext: str = "txt"
+) -> str:
+    """A ZIP-safe ``Artist - Song.<ext>`` name, disambiguated by the (globally
     unique) song slug if two songs would otherwise collide — so no song is
     silently overwritten in the archive."""
     base = f"{artist.name} - {song.name}"
-    name = f"{base}.txt".replace("/", "_")
+    name = f"{base}.{ext}".replace("/", "_")
     suffix = 0
     while name in used:
         suffix += 1
         tag = song.slug if suffix == 1 else f"{song.slug}-{suffix}"
-        name = f"{base} ({tag}).txt".replace("/", "_")
+        name = f"{base} ({tag}).{ext}".replace("/", "_")
     return name
+
+
+_OPENLYRICS_NS = "http://openlyrics.info/namespace/2009/song"
+
+
+def _q(tag: str) -> str:
+    """Qualify a tag with the OpenLyrics namespace (Clark notation)."""
+    return f"{{{_OPENLYRICS_NS}}}{tag}"
+
+
+def _stanzas(content: str) -> list[list[str]]:
+    """Split a lyric into stanzas (on blank lines), each a list of non-empty
+    lines. These map onto OpenLyrics verses."""
+    stanzas = []
+    for block in re.split(r"\n\s*\n", content.strip()):
+        lines = [line.strip() for line in block.splitlines() if line.strip()]
+        if lines:
+            stanzas.append(lines)
+    return stanzas
+
+
+def _render_openlyrics(artist: Artist, song: Song, content: str) -> str:
+    """Render one admitted song as OpenLyrics 0.9 XML, the open format OpenLP
+    and Quelea import natively (title and author land in their own fields).
+    Stanzas become verses; line breaks within a stanza become ``<br/>``."""
+    ET.register_namespace("", _OPENLYRICS_NS)
+    song_el = ET.Element(_q("song"), version="0.9", createdIn="letras")
+
+    props = ET.SubElement(song_el, _q("properties"))
+    ET.SubElement(ET.SubElement(props, _q("titles")), _q("title")).text = song.name
+    ET.SubElement(ET.SubElement(props, _q("authors")), _q("author")).text = artist.name
+
+    lyrics_el = ET.SubElement(song_el, _q("lyrics"))
+    for index, lines in enumerate(_stanzas(content) or [[content.strip()]], start=1):
+        verse = ET.SubElement(lyrics_el, _q("verse"), name=f"v{index}")
+        lines_el = ET.SubElement(verse, _q("lines"))
+        lines_el.text = lines[0]
+        for line in lines[1:]:
+            ET.SubElement(lines_el, _q("br")).tail = line
+
+    body = ET.tostring(song_el, encoding="unicode")
+    return f'<?xml version="1.0" encoding="UTF-8"?>\n{body}\n'
 
 
 def _thousands(value: int) -> str:
     """Format an integer with Brazilian thousands separators (1234 -> '1.234')."""
     return f"{value:,}".replace(",", ".")
+
+
+def _format_date_br(stamp: str) -> str:
+    """Render a ``YYYYMMDD`` stamp as Brazilian ``DD/MM/YYYY``."""
+    return datetime.strptime(stamp, "%Y%m%d").strftime("%d/%m/%Y")
 
 
 def _render_notes(rows: list[tuple[Artist, Song, str]], date: str, scraped: int) -> str:
@@ -75,22 +138,24 @@ def _render_notes(rows: list[tuple[Artist, Song, str]], date: str, scraped: int)
     return (
         "\n".join(
             [
-                f"# Letras Gospel — {date}",
+                "# Letras gospel em português",
                 "",
-                "Letras gospel em português coletadas de letras.mus.br e "
-                "curadas para o corpus.",
+                "Milhares de letras de músicas evangélicas coletadas de "
+                "letras.mus.br.",
                 "",
                 "| Métrica | Total |",
                 "|---|---|",
                 f"| Músicas (admitidas) | {_thousands(len(rows))} |",
                 f"| Artistas | {_thousands(artists)} |",
                 f"| Coletadas (brutas) | {_thousands(scraped)} |",
-                f"| Gerado em | {date} |",
+                f"| Gerado em | {_format_date_br(date)} |",
                 "",
                 "## Downloads",
-                "- `corpus.db` — corpus completo em SQLite "
+                "- `letras-txt.zip`: um `.txt` por música (`Artista - Música.txt`)",
+                "- `letras-openlyrics.zip`: um `.xml` por música, "
+                "formato OpenLyrics (OpenLP, Quelea)",
+                "- `corpus.db`: tudo em um arquivo SQLite "
                 "(artists, songs, lyrics, language)",
-                "- `letras.zip` — um `.txt` por música (`Artista - Música.txt`)",
             ]
         )
         + "\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,7 +73,7 @@ def test_export_command_writes_release(tmp_path: Path) -> None:
 
     assert result.exit_code == 0, result.output
     assert (out / "corpus.db").exists()
-    zip_path = out / "letras.zip"
+    zip_path = out / "letras-txt.zip"
     assert zip_path.exists()
     with zipfile.ZipFile(zip_path) as archive:
         assert "Aline Barros - Consagração.txt" in archive.namelist()

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -94,10 +94,10 @@ def test_render_openlyrics_structure() -> None:
     root = ET.fromstring(xml)
     assert root.tag == f"{OL_NS}song"
     assert root.get("version") == "0.9"
-    title = root.find(f"{OL_NS}properties/{OL_NS}titles/{OL_NS}title")
-    author = root.find(f"{OL_NS}properties/{OL_NS}authors/{OL_NS}author")
-    assert title.text == "Consagração"
-    assert author.text == "Aline Barros"
+    title = root.findtext(f"{OL_NS}properties/{OL_NS}titles/{OL_NS}title")
+    author = root.findtext(f"{OL_NS}properties/{OL_NS}authors/{OL_NS}author")
+    assert title == "Consagração"
+    assert author == "Aline Barros"
     verses = root.findall(f"{OL_NS}lyrics/{OL_NS}verse")
     assert [v.get("name") for v in verses] == ["v1", "v2"]
     # two lines in a stanza -> one <br/> joining them
@@ -112,10 +112,10 @@ def test_render_openlyrics_escapes_special_characters() -> None:
     xml = _render_openlyrics(artist, song, "Glória & paz\n<aleluia>")
     root = ET.fromstring(xml)  # parses only if every value is escaped
 
-    title = root.find(f"{OL_NS}properties/{OL_NS}titles/{OL_NS}title")
-    author = root.find(f"{OL_NS}properties/{OL_NS}authors/{OL_NS}author")
-    assert title.text == "Fé <viva>"
-    assert author.text == "A & B"
+    title = root.findtext(f"{OL_NS}properties/{OL_NS}titles/{OL_NS}title")
+    author = root.findtext(f"{OL_NS}properties/{OL_NS}authors/{OL_NS}author")
+    assert title == "Fé <viva>"
+    assert author == "A & B"
 
 
 def test_export_release_writes_openlyrics_zip(tmp_path: Path) -> None:

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,10 +1,17 @@
+import xml.etree.ElementTree as ET
 import zipfile
 from pathlib import Path
 
 from letras.domain.entities import Artist, Song
 from letras.domain.policy import load_policy
-from letras.release.exporter import _render_notes, export_release
+from letras.release.exporter import (
+    _render_notes,
+    _render_openlyrics,
+    export_release,
+)
 from letras.store.corpus_store import CorpusStore
+
+OL_NS = "{http://openlyrics.info/namespace/2009/song}"
 
 GOOD = "Louvarei ao Senhor de todo o meu coração e exaltarei o Teu nome " * 4
 
@@ -22,7 +29,7 @@ def test_export_release_includes_only_admitted_songs(tmp_path: Path) -> None:
     export_release(store, db_path, out, date="20260615", policy=load_policy())
 
     assert (out / "corpus.db").exists()
-    with zipfile.ZipFile(out / "letras.zip") as archive:
+    with zipfile.ZipFile(out / "letras-txt.zip") as archive:
         names = archive.namelist()
     assert "Aline Barros - Consagração.txt" in names
     assert "Aline Barros - Short.txt" not in names
@@ -31,6 +38,7 @@ def test_export_release_includes_only_admitted_songs(tmp_path: Path) -> None:
     assert "| Músicas (admitidas) | 1 |" in notes
     assert "| Artistas | 1 |" in notes
     assert "| Coletadas (brutas) | 2 |" in notes  # Consagração ok, Short rejeitada
+    assert "| Gerado em | 15/06/2026 |" in notes  # Brazilian DD/MM/YYYY
 
 
 def test_render_notes_is_bounded_and_omits_per_artist_list() -> None:
@@ -51,6 +59,8 @@ def test_render_notes_is_bounded_and_omits_per_artist_list() -> None:
     assert "Artista 04000" not in notes  # individual artists are not listed
     assert "| Músicas (admitidas) | 8.000 |" in notes  # PT thousands separator
     assert "| Coletadas (brutas) | 9.000 |" in notes
+    assert "| Gerado em | 16/06/2026 |" in notes  # Brazilian DD/MM/YYYY
+    assert "—" not in notes  # em-dashes removed (humanized)
 
 
 def test_export_zip_disambiguates_colliding_filenames(tmp_path: Path) -> None:
@@ -67,7 +77,60 @@ def test_export_zip_disambiguates_colliding_filenames(tmp_path: Path) -> None:
 
     export_release(store, db_path, out, date="20260616", policy=load_policy())
 
-    with zipfile.ZipFile(out / "letras.zip") as archive:
+    with zipfile.ZipFile(out / "letras-txt.zip") as archive:
         names = archive.namelist()
     assert len(names) == 2  # both songs written
     assert len(set(names)) == 2  # under distinct names — no silent overwrite
+
+
+def test_render_openlyrics_structure() -> None:
+    artist = Artist(name="Aline Barros", slug="aline-barros")
+    song = Song(name="Consagração", slug="44039")
+    content = "Linha um\nLinha dois\n\nLinha três\nLinha quatro"
+
+    xml = _render_openlyrics(artist, song, content)
+
+    assert xml.startswith('<?xml version="1.0" encoding="UTF-8"?>')
+    root = ET.fromstring(xml)
+    assert root.tag == f"{OL_NS}song"
+    assert root.get("version") == "0.9"
+    title = root.find(f"{OL_NS}properties/{OL_NS}titles/{OL_NS}title")
+    author = root.find(f"{OL_NS}properties/{OL_NS}authors/{OL_NS}author")
+    assert title.text == "Consagração"
+    assert author.text == "Aline Barros"
+    verses = root.findall(f"{OL_NS}lyrics/{OL_NS}verse")
+    assert [v.get("name") for v in verses] == ["v1", "v2"]
+    # two lines in a stanza -> one <br/> joining them
+    assert len(verses[0].findall(f"{OL_NS}lines/{OL_NS}br")) == 1
+
+
+def test_render_openlyrics_escapes_special_characters() -> None:
+    # Names and lyrics carry & < >; the XML must stay well-formed.
+    artist = Artist(name="A & B", slug="a-b")
+    song = Song(name="Fé <viva>", slug="x")
+
+    xml = _render_openlyrics(artist, song, "Glória & paz\n<aleluia>")
+    root = ET.fromstring(xml)  # parses only if every value is escaped
+
+    title = root.find(f"{OL_NS}properties/{OL_NS}titles/{OL_NS}title")
+    author = root.find(f"{OL_NS}properties/{OL_NS}authors/{OL_NS}author")
+    assert title.text == "Fé <viva>"
+    assert author.text == "A & B"
+
+
+def test_export_release_writes_openlyrics_zip(tmp_path: Path) -> None:
+    db_path = tmp_path / "corpus.db"
+    store = CorpusStore(db_path)
+    artist_id = store.upsert_artist(Artist(name="Aline Barros", slug="aline-barros"))
+    song_id = store.upsert_song(Song(name="Consagração", slug="44039"), artist_id)
+    store.set_lyrics(song_id, GOOD, "pt", len(GOOD))
+    out = tmp_path / "dist"
+
+    export_release(store, db_path, out, date="20260616", policy=load_policy())
+
+    zip_path = out / "letras-openlyrics.zip"
+    assert zip_path.exists()
+    with zipfile.ZipFile(zip_path) as archive:
+        assert "Aline Barros - Consagração.xml" in archive.namelist()
+        xml = archive.read("Aline Barros - Consagração.xml").decode("utf-8")
+    assert ET.fromstring(xml).tag == f"{OL_NS}song"


### PR DESCRIPTION
## Release outputs
- **New:** per-song OpenLyrics XML bundle (`letras-openlyrics.zip`), the open format OpenLP and Quelea import natively, with title and author in their own fields.
- Rename `letras.zip` to `letras-txt.zip` (parallel to the xml bundle).
- `RELEASE_NOTES.md` now lives only in the release body, not as an attached asset.
- Dates render as Brazilian `DD/MM/YYYY`; the release title is unified to `Letras DDMMYYYY` (no full/incremental suffix).
- Em-dashes stripped from the notes.

## README
- New title and subtitle aimed at projection software, in plain language.
- Removed the test badge and the legal notice.
- Download buttons moved into the header; the SQLite button is replaced by the OpenLyrics (.xml) download.
- OpenLyrics artifact documented in Conteúdo.

## Tests
- Three new exporter tests (OpenLyrics structure, XML escaping, zip integration). 54 passing, ruff clean.

> The OpenLyrics XML follows the 0.9 spec and is validated for well-formedness in tests, but still needs a spot-check by importing into the real OpenLP/Quelea apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
